### PR TITLE
Feat: Implement get_user_assets Function in Piggystark Smart Contract

### DIFF
--- a/contracts/src/interfaces/ierc20.cairo
+++ b/contracts/src/interfaces/ierc20.cairo
@@ -1,18 +1,20 @@
 use starknet::ContractAddress;
 
 #[starknet::interface]
-pub trait IERC20<TContractState>{
+pub trait IERC20<TContractState> {
     fn get_name(self: @TContractState) -> ByteArray;
     fn get_symbol(self: @TContractState) -> ByteArray;
     fn get_decimals(self: @TContractState) -> u8;
-    
+
     fn get_total_supply(self: @TContractState) -> u256;
     fn get_balance_of(self: @TContractState, account: ContractAddress);
     fn get_allowance(self: @TContractState, owner: ContractAddress, spender: ContractAddress);
 
     fn approve(ref self: TContractState, spender: ContractAddress, amount: u256);
     fn transfer(ref self: TContractState, recipient: ContractAddress, amount: u256);
-    fn transfer_from(ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256);
+    fn transfer_from(
+        ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256,
+    );
 
     fn mint(ref self: TContractState, recipient: ContractAddress, amount: u256);
-}   
+}

--- a/contracts/src/interfaces/ipiggystark.cairo
+++ b/contracts/src/interfaces/ipiggystark.cairo
@@ -1,5 +1,5 @@
-use starknet::ContractAddress;
 use contracts::structs::piggystructs::Asset;
+use starknet::ContractAddress;
 
 #[starknet::interface]
 pub trait IPiggyStark<TContractState> {

--- a/contracts/src/lib.cairo
+++ b/contracts/src/lib.cairo
@@ -1,6 +1,6 @@
 pub mod interfaces {
-    pub mod ipiggystark;
     pub mod ierc20;
+    pub mod ipiggystark;
 }
 
 pub mod structs {

--- a/contracts/src/piggystark.cairo
+++ b/contracts/src/piggystark.cairo
@@ -1,28 +1,50 @@
 #[starknet::contract]
 pub mod PiggyStark {
-    use contracts::{
-        interfaces::ipiggystark::IPiggyStark, 
-        structs::piggystructs::Asset
-    };
-    use starknet::ContractAddress;
+    use contracts::interfaces::ipiggystark::IPiggyStark;
+    use contracts::structs::piggystructs::Asset;
+    use core::num::traits::Zero;
+    use starknet::storage::{Map, StoragePathEntry, StoragePointerReadAccess};
+    use starknet::{ContractAddress, get_caller_address};
+
     #[storage]
     struct Storage {
-       owner: ContractAddress,
-       // Mapping from user address to the token address they deposited
-        deposited_token: LegacyMap<ContractAddress, ContractAddress>,
+        owner: ContractAddress,
+        // Mapping from user address to the token address they deposited
+        deposited_token: Map<ContractAddress, ContractAddress>,
         // Mapping from (user address, token address) to deposit amount
-        deposit_values: LegacyMap<(ContractAddress, ContractAddress), u256>,
+        deposit_values: Map<(ContractAddress, ContractAddress), u256>,
     }
 
-    fn constructor(){
-
-    }
+    fn constructor() {}
 
     #[abi(embed_v0)]
     impl PiggyStarkImpl of IPiggyStark<ContractState> {
         fn deposit(ref self: ContractState, token_address: ContractAddress, amount: u256) {}
         fn withdraw(ref self: ContractState, token_address: ContractAddress, amount: u256) {}
-        fn get_user_assets(self: @ContractState) -> Array<Asset> {}
+
+        fn get_user_assets(self: @ContractState) -> Array<Asset> {
+            let caller = get_caller_address();
+            let mut assets = ArrayTrait::new();
+
+            // Get the token address for the caller
+            let token_address = self.deposited_token.entry(caller).read();
+
+            // If the user has deposited a token (address is not zero)
+            if !token_address.is_zero() {
+                let amount = self.deposit_values.entry((caller, token_address)).read();
+                assets
+                    .append(
+                        Asset {
+                            token_name: "PIGGY STARK", //hardcoded this since, I don't see where token name is coming from
+                            token_address,
+                            balance: amount,
+                        },
+                    );
+            }
+
+            assets
+        }
+
         fn get_token_balance(self: @ContractState, token_address: ContractAddress) {}
     }
 }

--- a/contracts/src/structs/piggystructs.cairo
+++ b/contracts/src/structs/piggystructs.cairo
@@ -2,7 +2,7 @@ use starknet::ContractAddress;
 
 #[derive(Drop, Serde, starknet::Store)]
 pub struct Asset {
-    token_name: ByteArray,
-    token_address: ContractAddress,
-    balance: u256
+    pub token_name: ByteArray,
+    pub token_address: ContractAddress,
+    pub balance: u256,
 }

--- a/contracts/tests/test_contract.cairo
+++ b/contracts/tests/test_contract.cairo
@@ -1,11 +1,9 @@
+use contracts::{
+    IHelloStarknetDispatcher, IHelloStarknetDispatcherTrait, IHelloStarknetSafeDispatcher,
+    IHelloStarknetSafeDispatcherTrait,
+};
+use snforge_std::{ContractClassTrait, DeclareResultTrait, declare};
 use starknet::ContractAddress;
-
-use snforge_std::{declare, ContractClassTrait, DeclareResultTrait};
-
-use contracts::IHelloStarknetSafeDispatcher;
-use contracts::IHelloStarknetSafeDispatcherTrait;
-use contracts::IHelloStarknetDispatcher;
-use contracts::IHelloStarknetDispatcherTrait;
 
 fn deploy_contract(name: ByteArray) -> ContractAddress {
     let contract = declare(name).unwrap().contract_class();
@@ -42,6 +40,6 @@ fn test_cannot_increase_balance_with_zero_value() {
         Result::Ok(_) => core::panic_with_felt252('Should have panicked'),
         Result::Err(panic_data) => {
             assert(*panic_data.at(0) == 'Amount cannot be 0', *panic_data.at(0));
-        }
+        },
     };
 }


### PR DESCRIPTION
## Overview
This PR implements the get_user_assets function in the PiggyStark contract, allowing users to retrieve their deposited assets. The implementation follows Starknet best practices and maintains consistency with the existing contract architecture.

## Related Issue
This PR close #4 

## Changes Made
- **Core Implementation**
     - Implemented `get_user_assets()` to return an array of `Asset` structs containing:
         - Token address (from `deposited_token` mapping)
         - Deposit amount (from `deposit_values` mapping)
         - Token name (currently hardcoded as "PIGGY STARK")
     - Used modern `Map` storage type instead of deprecated `LegacyMap`
     - Added proper storage access patterns using `entry().read()`
     - Implemented zero-address check for deposited tokens

- **Structural Improvements**
     - Made all `Asset` struct fields public for accessibility
     - Added necessary imports (`Zero` trait, storage access types)
     - Maintained consistent error handling for non-existent users
 

