### PR TITLE
feat: implement create_target 

### DIFF
--- a/src/errors/piggystark_errors.cairo
+++ b/src/errors/piggystark_errors.cairo
@@ -12,6 +12,8 @@ pub mod Errors {
         pub NO_TOKENS_AVAILABLE: felt252,
         pub SHOULD_HAVE_NO_TOKENS: felt252,
         pub INCORRECT_BALANCE: felt252,
+        pub ZERO_GOAL_AMOUNT: felt252,
+        pub INVALID_DEADLINE: felt252,
     }
 
     pub fn new() -> Errors {
@@ -27,6 +29,8 @@ pub mod Errors {
             NO_TOKENS_AVAILABLE: 'no tokens available',
             SHOULD_HAVE_NO_TOKENS: 'should have no tokens',
             INCORRECT_BALANCE: 'incorrect balance',
+            ZERO_GOAL_AMOUNT: 'Goal amount cannot be zero',
+            INVALID_DEADLINE: 'Invalid deadline',
         }
     }
 }

--- a/src/interfaces/ipiggystark.cairo
+++ b/src/interfaces/ipiggystark.cairo
@@ -51,7 +51,9 @@ pub trait IPiggyStark<TContractState> {
     /// @param goal The target amount to save (must be > 0).
     /// @param deadline The timestamp (in seconds) when the target expires.
     /// @return The unique ID of the created target.
-    // fn create_target(ref self: TContractState, token_address: ContractAddress, goal: u256, deadline: u64) -> u64;
+    fn create_target(
+        ref self: TContractState, token_address: ContractAddress, goal: u256, deadline: u64,
+    ) -> u64;
 
     /// Contributes an amount to an existing savings target.
     /// Funds are moved from the flexible balance to the target and may be allocated to Nostra.

--- a/src/structs/piggystructs.cairo
+++ b/src/structs/piggystructs.cairo
@@ -6,3 +6,11 @@ pub struct Asset {
     pub token_address: ContractAddress,
     pub balance: u256,
 }
+
+#[derive(Copy, Drop, Serde, starknet::Store)]
+pub struct SavingsTarget {
+    pub id: u64,
+    pub token_address: ContractAddress,
+    pub goal: u256,
+    pub deadline: u64,
+}


### PR DESCRIPTION
## Description

This PR implements the `create_target` function in the `PiggyStark` contract as described in issue #27 .

## Changes

### Storage

- Added `targets_count: u64`: Tracks the total number of targets created and used to generates unique target IDs.

- Added `targets: Map<u64, SavingsTarget>`: Maps each target ID to its corresponding `SavingsTarget` data.

### Structs

- Added a new struct in `piggystructs.cairo`:

```cairo
#[derive(Copy, Drop, Serde, starknet::Store)]
pub struct SavingsTarget {
    pub id: u64,
    pub token_address: ContractAddress,
    pub goal: u256,
    pub deadline: u64,
}
```

### Functions

- Implemented `create_target`: Allows users to create a new savings target.
    - Performs basic validations (token address not zero, goal amount not zero, valid deadline).
    - Generates a unique target ID.
    - Stores the new target data in `targets` storage.
    - Emits a `TargetCreated` event.
    - Returns the target ID.

### Events

- Added `TargetCreated`: Emitted when a new savings target is created.

### Errors

- Added new error constants:
    - `INVALID_GOAL_AMOUNT`: Thrown when the goal amount is zero.
    - `INVALID_DEADLINE`: Thrown when the deadline is not in the future.

### Testing

Added comprehensive test coverage for all edge cases.

---- 

Let me know if any changes are needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to create savings targets with a specific token, goal amount, and deadline.
  - Added event notifications when a new savings target is created.

- **Bug Fixes**
  - Improved input validation with clearer error messages for zero goal amounts and invalid deadlines.

- **Tests**
  - Added comprehensive tests for creating savings targets, including success cases and input validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->